### PR TITLE
[IMP] use xmlsec python library, remove m2crypto

### DIFF
--- a/README
+++ b/README
@@ -12,11 +12,10 @@ way it works.
 Dependencies
 ------------
 * lxml
-* m2crypto
-* xmlsec (non-python, http://www.aleksey.com/xmlsec/)
+* xmlsec
 
-The module has been run using python 2.6.5 and 2.5.2 deployments, but other
-versions might work as well.
+The module has been run using python 2.7.10, 2.6.5 and 2.5.2 deployments, but
+other versions might work as well.
 
 Example
 -------
@@ -41,23 +40,5 @@ connector.request_transaction_status(self, transaction_id)
 
 Problem?
 --------
-You will probably have issues on Ubuntu with M2Crypto, specifically the error:
-
-    _m2crypto.so: undefined symbol: SSLv2_method
-
-Use this script to install M2Crypto in your virtualenv and all will be fine
-https://github.com/Motiejus/django-webtopay/blob/master/m2crypto_ubuntu
-
-Additionally, on Ubuntu 13.10+ when building m2crypto it may be unable to
-find openssl/opensslconf.h. This can be fixed by adding the path to it to your
-~/.pydistutils.cfg as shown below. Note that the path to the correct include 
-dir may vary based on your architecture.
-
-cat ~/.pydistutils.cfg
-[global]
-include_dirs = /usr/include/x86_64-linux-gnu/
-
-Finally, another common problem is forgetting to install xmlsec. This will
-results in a "[Errno 2] No such file or directory" error when calling most
-of the python-ideal functions. To fix this simply install xmlsec. (The package
-is named xmlsec1 on Debian/Ubuntu)
+If you have problems installing xmlsec, install packages python-pkgconfig and
+libxmlsec1-dev

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from distutils.core import setup
 setup(name='python-ideal',
-      version='0.2',
+      version='0.2.1',
       py_modules=['ideal'],
 )
 


### PR DESCRIPTION
This patch removes the dependency on m2crypto, which is quite heavy and only used for calculating key fingerprints, and introduces a dependency to xmlsec (https://github.com/mehcode/python-xmlsec). Then it also removes calling xmlsec as subprocess, using up less resources this way, but more important, allowing to use keys and certificates that don't live in the file system. It might also be undesirable that you can see the key's password if you display a process list at the right moment.

The API supports what it supoprted before, so no code changes necessary.